### PR TITLE
ssh: change log level of ssh connection to DEBUG

### DIFF
--- a/ssh.tcl
+++ b/ssh.tcl
@@ -34,7 +34,7 @@ namespace eval ::9pm::ssh {
         send "$ssh_cmd\n"
         expect {
             $PROMPT {
-                ::9pm::output::info "Connected to \"$IP\" (as \"$USER\")"
+                ::9pm::output::debug "Connected to \"$IP\" (as \"$USER\")"
             }
             -nocase "password" {
                 send "$PASS\n"


### PR DESCRIPTION
This is the only log message in 9pm that is info level. Now that there
are multiple debug levels in 9pm bump this back a level to DEBUG and
leave INFO to users of 9pm.