### PR TITLE
conifg: expand <config> to configuration file path

### DIFF
--- a/config.tcl
+++ b/config.tcl
@@ -30,6 +30,15 @@ namespace eval ::9pm::conf {
         ::9pm::output::debug "Running without configuration"
     }
 
+    proc expand {var} {
+        # Define substitution $variables
+        set config [file normalize [file dirname $::9pm::core::cmdl(c)]]
+
+        set var [string map [list "<config>" $config] $var]
+
+        return $var
+    }
+
     proc get {node what} {
         variable data
 
@@ -47,7 +56,7 @@ namespace eval ::9pm::conf {
 
         # Try to return the info we want for this node
         if {[dict exists $node_info $what]} {
-            return [dict get $node_info $what]
+            return [expand [dict get $node_info $what]]
         } else {
             ::9pm::output::debug2 "Configuration data \"$what\" not found for node \"$node\""
             return ""


### PR DESCRIPTION
It is sometimes useful to point out files in a configuration file
relative itself. One example is if the targets ssh keys are stored
together with the configuration file. Example file structure could look
like:

foo/config/myconf.yaml
foo/config/mysshkey

With a node configuration inside myconf.yaml pointing out the ssh key:

node:
    SSH_IP: 1.2.3.4
    SSH_USER: root
    SSH_KEYFILE: <config>/mysshkey