### PR TITLE
shell: Don't use bash initialization file

### DIFF
--- a/shell.tcl
+++ b/shell.tcl
@@ -19,7 +19,7 @@
 package provide 9pm::shell 1.0
 
 namespace eval ::9pm::shell {
-    proc open {alias {shell "/bin/bash"}} {
+    proc open {alias {shell "/bin/bash -norc"}} {
         global spawn_id
         variable data
         variable active

--- a/unit_tests/execute_test/execute_test.tcl
+++ b/unit_tests/execute_test/execute_test.tcl
@@ -64,7 +64,7 @@ if {[llength $lines] == $TESTDATA_LINE_CNT} {
 
 output::info "Testing command nesting"
 
-cmd::start "/bin/bash"
+cmd::start "/bin/bash -norc"
 set lines [cmd::execute "cat [misc::get::running_script_path]/testdata"]
 send "exit\n"
 cmd::finish


### PR DESCRIPTION
Do not read and execute the system wide initialization file
/etc/bash.bashrc and the personal initialization file ~/.bashrc when
spawning bash.