### PR TITLE
9pm.py: explicitly state python2 interpreter

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 
 # Copyright (C) 2011-2017 Richard Alpe <rical@highwind.se>
 #


### PR DESCRIPTION
Python version 2 is used in this script while the interpreter where set
to /usr/bin/python. This breaks on systems where the /usr/bin/python is
a symlink to a python3 interpreter. According to pep-0394 [1] it is
recommended to instead use the /usr/bin/python2 which should be symlink
to a python2 interpreter.

1. https://www.python.org/dev/peps/pep-0394/

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>