### PR TITLE
9pm.py: fix spelling error

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -248,7 +248,7 @@ for opt, arg in options:
 temp = tempfile.NamedTemporaryFile(suffix='_dict_db', prefix='9pm_',
                                    dir='/tmp')
 if DEBUG:
-    print "Created databsefile:", temp.name
+    print "Created databasefile:", temp.name
 DATABASE = temp.name
 
 cmdl = {'name': 'cmdl', 'suite': []}


### PR DESCRIPTION
"database" was missing an "a", fix it.

Signed-off-by: Andreas Bofjall <andreas@gazonk.org>