### PR TITLE
9pm.py: make methods importable

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -227,44 +227,50 @@ def run_suite(data, depth):
 
     return err
 
-# MAIN
-
-print(pcolor.yellow + "9PM - Simplicity is the ultimate sophistication"
+def main():
+    global CMDL_OPTIONS
+    global CONFIG
+    global DATABASE
+    global DEBUG
+    print(pcolor.yellow + "9PM - Simplicity is the ultimate sophistication"
       + pcolor.reset);
 
-options, remainder = getopt.getopt(sys.argv[1:], 'dho:c:',
-                                   ['debug', 'option=', 'config=', 'help'])
-for opt, arg in options:
-    if opt in ('-d', '--debug'):
-        print "Debug switched on"
-        DEBUG = True
-    elif opt in ('-o', '--option'):
-        CMDL_OPTIONS.append(arg)
-    elif opt in ('-c', '--config'):
-        CONFIG = arg;
-    elif opt in ('-h', '--help'):
-        help()
+    options, remainder = getopt.getopt(sys.argv[1:], 'dho:c:',
+                                       ['debug', 'option=', 'config=', 'help'])
+    for opt, arg in options:
+        if opt in ('-d', '--debug'):
+            print "Debug switched on"
+            DEBUG = True
+        elif opt in ('-o', '--option'):
+            CMDL_OPTIONS.append(arg)
+        elif opt in ('-c', '--config'):
+            CONFIG = arg;
+        elif opt in ('-h', '--help'):
+            help()
 
-temp = tempfile.NamedTemporaryFile(suffix='_dict_db', prefix='9pm_',
-                                   dir='/tmp')
-if DEBUG:
-    print "Created databasefile:", temp.name
-DATABASE = temp.name
+    temp = tempfile.NamedTemporaryFile(suffix='_dict_db', prefix='9pm_',
+                                       dir='/tmp')
+    if DEBUG:
+        print "Created databasefile:", temp.name
+    DATABASE = temp.name
 
-cmdl = {'name': 'cmdl', 'suite': []}
-for filename in remainder:
-    fpath = os.path.join(os.getcwd(), filename)
-    if filename.endswith('.yaml'):
-        cmdl['suite'].append(parse(fpath))
+    cmdl = {'name': 'cmdl', 'suite': []}
+    for filename in remainder:
+        fpath = os.path.join(os.getcwd(), filename)
+        if filename.endswith('.yaml'):
+            cmdl['suite'].append(parse(fpath))
+        else:
+            cmdl['suite'].append({"case": fpath, "name": gen_name(filename)})
+
+    err = run_suite(cmdl, 0)
+    if err:
+        print pcolor.red + "\nx Execution" + pcolor.reset
     else:
-        cmdl['suite'].append({"case": fpath, "name": gen_name(filename)})
+        print pcolor.green + "\no Execution" + pcolor.reset
+    print_tree(cmdl, "", 0)
 
-err = run_suite(cmdl, 0)
-if err:
-    print pcolor.red + "\nx Execution" + pcolor.reset
-else:
-    print pcolor.green + "\no Execution" + pcolor.reset
-print_tree(cmdl, "", 0)
+    temp.close()
+    exit(err)
 
-temp.close()
-exit(err)
+if __name__ == '__main__':
+    main()

--- a/unit_tests/helpers/retry_test.tcl
+++ b/unit_tests/helpers/retry_test.tcl
@@ -52,9 +52,9 @@ proc runtime {wait times delay} {
 
 proc test_runtime {wait times delay expected} {
     if {$expected} {
-        set msg "Run $wait seconds in $times cycels and $delay second delay"
+        set msg "Run $wait seconds in $times cycles and $delay second delay"
     } else {
-        set msg "Fail to run $wait seconds in $times cycels and $delay second delay"
+        set msg "Fail to run $wait seconds in $times cycles and $delay second delay"
     }
 
     if {[runtime $wait $times $delay] != $expected} {


### PR DESCRIPTION
Create a function main() and call it via the standard python "if
__name__ == '__main__'" construct, thereby making the methods in 9pm.py
importable from another python file without (accidentally) running the
code in main. This allows e.g. unit testing in the future.

Signed-off-by: Andreas Bofjall <andreas@gazonk.org>