### PR TITLE
9pm: include seconds in log stamp time

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -87,7 +87,7 @@ def run_test(test):
             break
 
         string = line.rstrip()
-        stamp = time.strftime("%Y-%m-%d %H:%M")
+        stamp = time.strftime("%Y-%m-%d %H:%M:%S")
 
         plan = re.search('^(\d+)..(\d+)$', string)
         ok = re.search('^ok (\d+) -', string)


### PR DESCRIPTION
When running tests it's useful to see the approximated time between each
log output. Add seconds to the log format.

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>