### PR TITLE
Add install.tcl and avoid requiring rc file

### DIFF
--- a/README
+++ b/README
@@ -16,6 +16,17 @@ You should have received a copy of the GNU General Public License
 along with this program; if not, write to the Free Software
 Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 
+INSTALLATION
+------------
+
+Check where your distribution normally installs tcl libraries by examining
+the $tcl_pkgPath . Choose a suitable directory and ensure it exists.
+
+Run
+
+./install.tcl <directory>
+
+
 WHY 9PM
 -------
 9pm is designed to address the complexity of interactively managing different

--- a/init.tcl
+++ b/init.tcl
@@ -62,7 +62,7 @@ namespace eval ::9pm::core {
 
     if {[file exists "~/.9pm.rc"]} {
         set rc [parse_yaml "~/.9pm.rc"]
-    } else {
+    } elseif {[file exists "$::9pm::root_path/etc/9pm.rc"]} {
         set rc [parse_yaml "$::9pm::root_path/etc/9pm.rc"]
     }
 

--- a/install.tcl
+++ b/install.tcl
@@ -1,0 +1,40 @@
+#!/usr/bin/tclsh
+
+set version 1.0
+
+set file_list {
+    "config.tcl"
+    "db.tcl"
+    "execute.tcl"
+    "helpers.tcl"
+    "init.tcl"
+    "output.tcl"
+    "pkgAll.tcl"
+    "pkgIndex.tcl"
+    "scp.tcl"
+    "shell.tcl"
+    "ssh.tcl"
+}
+
+if {"$argc" != 1} {
+    puts stderr "No install path provided, not installing!"
+    exit 1
+} else {
+    set install_path [string trimright [lindex $argv 0] /]
+}
+
+if {[lsearch $auto_path "$install_path"] == -1} {
+    puts stderr "$install_path is not in \$auto_path, needed for package loading"
+    exit 1
+}
+
+set 9pm_install_dir "$install_path/9pm$version"
+
+if [catch {file mkdir -path "$9pm_install_dir"}] {
+    puts stderr "Could not create $9pm_install_dir, verify that you have write permissions"
+    exit 1
+}
+
+foreach install_file "$file_list" {
+    file copy "$install_file" "$9pm_install_dir"
+}


### PR DESCRIPTION
Add an install.tcl script to simplify installation. Also avoid
requiring a rc file in an etc directory as this is not strictly
needed for execution.