### PR TITLE
9pm.py: Specify YAML loader

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -154,7 +154,7 @@ def gen_name(filename):
 def parse_yaml(path):
     with open(path, 'r') as stream:
         try:
-            data = yaml.load(stream)
+            data = yaml.load(stream, Loader=yaml.FullLoader)
         except yaml.YAMLError as exc:
             print(exc)
             return -1


### PR DESCRIPTION
Use of PyYAML's yaml.load function without specifying the Loader=...
parameter, has been deprecated [1]. Solve this by specifying the
FullLoader.

1. https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>