### PR TITLE
execute: Align start check with end check schema

### DIFF
--- a/execute.tcl
+++ b/execute.tcl
@@ -103,10 +103,10 @@ namespace eval ::9pm::cmd {
         }
 
         expect *
-        send "echo $checksum(start); $cmd; echo $checksum(end) \$?\n"
+        send "echo $checksum(start) \$\$; $cmd; echo $checksum(end) \$?\n"
         expect {
             -timeout 10
-            -re "\r\n$checksum(start)\r\n" {
+            -re "$checksum(start) (\[0-9]+)\r\n" {
                 ::9pm::output::debug2 "\"$cmd\" started"
                 ::9pm::output::debug2 "\"$cmd\" start checksum $checksum(start)"
                 ::9pm::output::debug2 "\"$cmd\" end checksum $checksum(end)"


### PR DESCRIPTION
Instead of depending on the start checksum to be printed on a separate
line align the check to match that of the end checksum. Print the start
checksum followed by a expression that will evaluate to a number ($$
evaluates to PID) that demonstrates the console is active.

This have no effect on spawns of ssh connections but greatly
improves reliability of spawns dealing with serial consoles.

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>