### PR TITLE
Readd skip support

### DIFF
--- a/output.tcl
+++ b/output.tcl
@@ -109,7 +109,7 @@ namespace eval ::9pm::output {
         variable testnum
 
         incr testnum
-        write "ok $testnum - # skip $msg" YELLOW
+        write "ok $testnum # skip $msg" YELLOW
         return TRUE
     }
 


### PR DESCRIPTION
The way skip support is added back hints at that a better design of the internal representation of the internal tree of tests probably can be found. Hopefully such a rework could also consider how to write test reports to file. But this is a much larger task and to restore the skip state and fix old test-cases this builds upon the current design. 