### PR TITLE
execute: Correct assumption about shell behavior

### DIFF
--- a/execute.tcl
+++ b/execute.tcl
@@ -105,7 +105,7 @@ namespace eval ::9pm::cmd {
         }
 
         expect *
-        set sendcmd "echo $checksum(start); $cmd; echo $checksum(end) \$?\n"
+        set sendcmd "echo $checksum(start) \$\$; $cmd; echo $checksum(end) \$?\n"
         if {[dict exists $opts "send_slow"]} {
             set send_slow [dict get $opts "send_slow"]
             send -s $sendcmd
@@ -115,7 +115,7 @@ namespace eval ::9pm::cmd {
 
         expect {
             -timeout 10
-            -re "\r\n$checksum(start)\r\n" {
+            -re "$checksum(start) (\[0-9]+)\r\n" {
                 ::9pm::output::debug2 "\"$cmd\" started"
                 ::9pm::output::debug2 "\"$cmd\" start checksum $checksum(start)"
                 ::9pm::output::debug2 "\"$cmd\" end checksum $checksum(end)"

--- a/unit_tests/shell/shell_test.tcl
+++ b/unit_tests/shell/shell_test.tcl
@@ -30,7 +30,7 @@ proc check_pid {alias} {
     send "echo \$\$\n"
 
     expect {
-        -re {\r\n([0-9]+)\r\n} {
+        -re {([0-9]+)\r\n} {
            if {[dict get $9pm::shell::data($alias) "pid"] != $expect_out(1,string)} {
                 fatal output::fail "Got different pid from shell then 9pm thinks it has" }
            }


### PR DESCRIPTION
There are little control of what is printed to the console between a
command inputted and the starts of the commands output. The 9pm library
assumes that the only thing printed between the two is a newline '\r\n'
as effect of the '\n' terminating the send operation.

This assumption have been observed to not always be true. Some systems
can and do inject extra characters between the two events which leads to
parts of 9pm to fail. Fix this by removing the assumption that the
output of a command inputted with send will always start with a '\r\n\'
sequence.

The most intrusive change is for ::9pm::cmd::execute where the start
checksum is enhanced to print the PID of the start checksum echo itself.
The idea is to have a more complex expression to match while only
depending on a string under our control.

For the unit-test the fix easier to see as it just removes the incorrect
assumption about shell behavior.

With these changes execute works and all unit tests pass.

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>