### PR TITLE
9pm.py: Remove unused depth argument

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -199,7 +199,7 @@ def parse(fpath):
             sys.exit(1)
     return suite
 
-def print_tree(data, base, depth):
+def print_tree(data, base):
     i = 1
     llen = len(data['suite'])
 
@@ -227,13 +227,13 @@ def print_tree(data, base, depth):
         print("{}{}{}{} {}{}".format(base, prefix, color, sign, test['name'], pcolor.reset))
 
         if 'suite' in test:
-            print_tree(test, nextbase, depth + 1)
+            print_tree(test, nextbase)
         i += 1
 
-def probe_suite(data, depth):
+def probe_suite(data):
     for test in data['suite']:
         if 'suite' in test:
-            probe_suite(test, depth + 2)
+            probe_suite(test)
         elif 'case' in test:
                 test['result'] = "noexec"
         else:
@@ -242,12 +242,12 @@ def probe_suite(data, depth):
 
     data['result'] = "noexec"
 
-def run_suite(cmdline, data, depth):
+def run_suite(cmdline, data):
     err = False
 
     for test in data['suite']:
         if 'suite' in test:
-            if run_suite(cmdline, test, depth + 2):
+            if run_suite(cmdline, test):
                 err = True
 
         elif 'case' in test:
@@ -341,16 +341,16 @@ def main():
         else:
             cmdl['suite'].append({"case": fpath, "name": gen_name(filename)})
 
-    probe_suite(cmdl, 0)
+    probe_suite(cmdl)
 
     setup_env(args)
 
-    err = run_suite(args, cmdl, 0)
+    err = run_suite(args, cmdl)
     if err:
         cprint(pcolor.red, "\nx Execution")
     else:
         cprint(pcolor.green, "\no Execution")
-    print_tree(cmdl, "", 0)
+    print_tree(cmdl, "")
 
     db.close()
     sys.exit(err)


### PR DESCRIPTION
The depth argument to print_tree(), probe_suite() and run_suite() are
unused and may be removed without any effect.

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>