### PR TITLE
output: Add wrapper to test and report result

### DIFF
--- a/output.tcl
+++ b/output.tcl
@@ -159,6 +159,16 @@ namespace eval ::9pm::output {
         }
     }
 
+    proc test {test msg} {
+        if {$test} {
+            ok $msg
+            return TRUE
+        } else {
+            fail $msg
+            return FALSE
+        }
+    }
+
     # Output setup
     set log_base [file normalize $::9pm::core::cmdl(l)]
     file mkdir $log_base

--- a/unit_tests/tap/test.tcl
+++ b/unit_tests/tap/test.tcl
@@ -1,0 +1,12 @@
+#!/usr/bin/tclsh
+
+package require 9pm
+namespace path ::9pm::
+
+output::plan 1
+
+proc test_hgtg { var } {
+    return [expr $var == 42]
+}
+
+output::test [test_hgtg 42] "This is a TAP from a test result"


### PR DESCRIPTION
The logging a test result as pass or fail based on a boolean variable is
not uncommon. I find myself often using a pattern like this,

    if {[sample_thermal_sensor]} {
        output::ok "Sample thermal sensor"
    } else {
        output::fail "Sample thermal sensor"
    }

To reduce the bloat in test-cases add a output::test helper to make this
use-case nicer to work with.

    output::test [sample_thermal_sensor] "Sample thermal sensor"

The helper also returns the test result so it can be used to clean up
after a failed test, in case the test script can recover and continue.

    if {![output::test [sample_thermal_sensor] "Sample thermal sensor"]} {
        emulate_thermal_sensor_values
    }

    use_thermal_sensor

Signed-off-by: Niklas Söderlund <niklas.soderlund@ragnatech.se>