### PR TITLE
Fix annoying warnings when running in a container

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -808,20 +808,21 @@ def run_git_cmd(path, command):
         with open(git_path, 'r') as f:
             line = f.read().strip()
             if line.startswith('gitdir: '):
-                gitdir = os.path.join(path, line[8:])
+                git_path = os.path.join(path, line[8:])
+                if not os.path.exists(git_path):
+                    return ""
             else:
                 vcprint(pcolor.orange, f"warning, invalid .git file format ({path})")
                 return ""
-    elif os.path.isdir(git_path):
-        gitdir = git_path
-    else:
+
+    if not os.path.isdir(git_path):
         vcprint(pcolor.orange, f"warning, no .git dir or file in path ({path})")
         return ""
 
     try:
-        vcprint(pcolor.faint, f"Running: git --git-dir {gitdir} {command}")
+        vcprint(pcolor.faint, f"Running: git --git-dir {git_path} {command}")
         result = subprocess.check_output(
-            ['git', '--git-dir', gitdir] + command,
+            ['git', '--git-dir', git_path] + command,
             stderr=subprocess.STDOUT
         ).decode('utf-8').strip()
     except Exception as e:


### PR DESCRIPTION
This is a follow-up to 07f28a4 which added support for figuring out the GIT revision when 9pm is a submodule in another proejct.

However, that project in turn may be a git worktree, where the actual .git directory is elsewhere, and when said project is running its tests from a Docker container, things get worse.  It is very likely that the actual .git directory is unreachable from within the container.

This patch hides the following annoying warnings:

```
warning, git command failed (Command '['git', '--git-dir', '/home/jocke/src/x-misc/test/9pm/../../../infix/.git/worktrees/x-misc/modules/9pm', 'rev-parse', 'HEAD']' returned non-zero exit status 128.)
9PM - Simplicity is the ultimate sophistication
warning, git command failed (Command '['git', '--git-dir', '/home/jocke/src/infix/.git/worktrees/x-misc', 'rev-parse', 'HEAD']' returned non-zero exit status 128.)

Testing Infix

Running suite 0001 all.yaml
    .
    . [snip]
    .
    `-- o 0031 Layer-2/3 tunnel tests
        |-- o 0032 Basic tunnel connectivity test
        |   |-- o 0033 GRE point-to-point
        |   |-- o 0034 GRETAP point-to-point
        |   `-- o 0035 VXLAN point-to-point
        `-- o 0036 Tunnel interface bridged with physical
            |-- o 0037 GRETAP bridged with physical interface
            `-- o 0038 VXLAN bridged with physical interface
warning, git command failed (Command '['git', '--git-dir', '/home/jocke/src/infix/.git/worktrees/x-misc', 'describe', '--tags', '--always']' returned non-zero exit status 128.)
warning, git command failed (Command '['git', '--git-dir', '/home/jocke/src/infix/.git/worktrees/x-misc', 'describe', '--tags', '--always']' returned non-zero exit status 128.)
warning, git command failed (Command '['git', '--git-dir', '/home/jocke/src/infix/.git/worktrees/x-misc', 'rev-parse', 'HEAD']' returned non-zero exit status 128.)

```