### PR TITLE
Fix test-spec -> test_spec in JSON output

### DIFF
--- a/9pm.py
+++ b/9pm.py
@@ -329,8 +329,8 @@ def parse_suite(suite_path, parent_suite_path, options, settings, name=None):
                 test_spec_path = get_test_spec_path(case['case'], settings['test-spec'])
                 if os.path.exists(test_spec_path):
                     vcprint(pcolor.faint, f"Found test specification: {test_spec_path} for {case['case']}")
-                    case['test-spec'] = test_spec_path
-                    case['test-spec-sha'] = calculate_sha1sum(test_spec_path)
+                    case['test_spec'] = test_spec_path
+                    case['test_spec_sha'] = calculate_sha1sum(test_spec_path)
                 else:
                         vcprint(pcolor.faint, f"No test specification for {case['case']} ({test_spec_path})")
 

--- a/self_test/cases/worker.adoc
+++ b/self_test/cases/worker.adoc
@@ -1,0 +1,3 @@
+= Worker Test Specification
+
+This is a test specification for the worker test case.

--- a/self_test/suites/test-spec.yaml
+++ b/self_test/suites/test-spec.yaml
@@ -1,0 +1,5 @@
+---
+- settings:
+    test-spec: <case>.adoc
+
+- case: "../cases/worker.py"

--- a/self_test/test_json_format.py
+++ b/self_test/test_json_format.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+"""Verify test_spec and test_spec_sha keys in JSON output"""
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from run import Test9pm
+
+if __name__ == "__main__":
+    tester = Test9pm()
+    try:
+        tester.test_spec_json_format()
+        sys.exit(0)
+    except AssertionError as e:
+        print(f"\n✗ Test failed: {e}")
+        sys.exit(1)
+    finally:
+        tester.cleanup()


### PR DESCRIPTION
The new report.py expects the test-spec key to be in a proper JSON compatible format.  I.e., it looks for `test_spec` rather than the old `test-spec` used previously.

This fixes the issue with missing test specification inline in the resulting PDF report.  See `Verify dynamic test-spec: <case>.adoc` for a before-after example.